### PR TITLE
Reduced contrast in accent buttons

### DIFF
--- a/src/variables.less
+++ b/src/variables.less
@@ -2,11 +2,11 @@
 @primary-color-dark: #00206f;
 @primary-color-text: white;
 @accent1-color: #91cc14;
-@accent1-color-med: #7cb209;
+@accent1-color-med: #88bf13;
 @accent1-color-dark: #689608;
 @accent1-color-text: black;
 @accent2-color: #FFB000;
-@accent2-color-med: #C28600;
+@accent2-color-med: #EAA000;
 @accent2-color-dark: #A87400;
 @accent2-color-text: black;
 @sidebar-color: gray;


### PR DESCRIPTION
I made the medium accent colors less dark, so that the accent buttons don't look so rounded. Now they're more similar to the primary buttons